### PR TITLE
RSS feed 输出文章全文

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,12 @@
     "lint-staged": "^13.0.0",
     "prettier": "^3.0.0",
     "prettier-plugin-tailwindcss": "^0.6.11",
-    "typescript": "^5.1.3"
+    "rehype-stringify": "^10.0.1",
+    "remark-mdx": "^3.1.0",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.1",
+    "typescript": "^5.1.3",
+    "unified": "^11.0.5"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [

--- a/scripts/mdxToHtml.mjs
+++ b/scripts/mdxToHtml.mjs
@@ -1,0 +1,320 @@
+/**
+ * Render a post's raw MDX body to standalone HTML for the RSS feed.
+ *
+ * Feed readers get no stylesheet and no React, so the site's JSX components and
+ * Tailwind-styled wrappers are worthless there — what matters is the prose,
+ * code and links inside them. This pipeline therefore parses the MDX, unwraps
+ * presentational JSX down to its content, maps the few components that carry
+ * real meaning onto semantic HTML, and absolutises every URL.
+ */
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkMdx from 'remark-mdx';
+import remarkRehype from 'remark-rehype';
+import rehypeStringify from 'rehype-stringify';
+import { visit } from 'unist-util-visit';
+
+/**
+ * JSX tags worth keeping, split by content model. Headings and inline elements
+ * cannot hold the paragraphs that a flow container would wrap their children
+ * in, so each group is rebuilt as the matching mdast node type instead.
+ */
+const BLOCK_AS = new Map([
+  ['Callout', 'blockquote'],
+  ['blockquote', 'blockquote'],
+  ['pre', 'pre'],
+  ['ul', 'ul'],
+  ['ol', 'ol'],
+  ['li', 'li'],
+  ['table', 'table'],
+  ['thead', 'thead'],
+  ['tbody', 'tbody'],
+  ['tr', 'tr'],
+  ['td', 'td'],
+  ['th', 'th'],
+]);
+
+/** `h1` becomes `h2`: the feed item's own title is the document's h1. */
+const HEADING_AS = new Map([
+  ['h1', 2],
+  ['h2', 2],
+  ['h3', 3],
+  ['h4', 4],
+  ['h5', 5],
+  ['h6', 6],
+]);
+
+const INLINE_AS = new Map([
+  ['strong', 'strong'],
+  ['b', 'strong'],
+  ['em', 'em'],
+  ['i', 'em'],
+  ['code', 'code'],
+  ['small', 'small'],
+]);
+
+const VOID_AS = new Map([
+  ['hr', { type: 'thematicBreak' }],
+  ['br', { type: 'break' }],
+]);
+
+/** Flatten block children into phrasing content for headings and inline tags. */
+function toPhrasing(children = []) {
+  const out = [];
+  for (const child of children) {
+    if (
+      child.children &&
+      !['link', 'strong', 'emphasis'].includes(child.type)
+    ) {
+      out.push(...toPhrasing(child.children));
+    } else {
+      out.push(child);
+    }
+  }
+  return out;
+}
+
+/** Attributes to carry over; everything else (className, style…) is dropped. */
+const KEEP_ATTRS = new Set(['href', 'src', 'alt', 'title']);
+
+function literalAttrs(node) {
+  const props = {};
+  for (const attr of node.attributes || []) {
+    if (attr.type !== 'mdxJsxAttribute') continue;
+    if (!KEEP_ATTRS.has(attr.name)) continue;
+    // Expression-valued props (`src={foo}`) cannot be resolved statically.
+    if (typeof attr.value === 'string') props[attr.name] = attr.value;
+  }
+  return props;
+}
+
+/** Read a literal string prop, used to salvage content from component props. */
+function stringProp(node, name) {
+  const attr = (node.attributes || []).find(
+    (a) => a.type === 'mdxJsxAttribute' && a.name === name,
+  );
+  return typeof attr?.value === 'string' ? attr.value : undefined;
+}
+
+/**
+ * Components whose content lives in props rather than children, so unwrapping
+ * alone would silently drop it.
+ */
+function fromProps(node) {
+  switch (node.name) {
+    case 'CopyableCodeBlock': {
+      const code = stringProp(node, 'code');
+      return code
+        ? [{ type: 'code', lang: stringProp(node, 'language'), value: code }]
+        : null;
+    }
+    case 'ErrorDisplay': {
+      const parts = [
+        stringProp(node, 'title'),
+        stringProp(node, 'error'),
+        stringProp(node, 'path'),
+      ].filter(Boolean);
+      return parts.length > 0
+        ? [{ type: 'code', value: parts.join('\n') }]
+        : null;
+    }
+    case 'Image': {
+      const src = stringProp(node, 'src');
+      return src
+        ? [
+            {
+              type: 'image',
+              url: src,
+              alt: stringProp(node, 'alt') || '',
+            },
+          ]
+        : null;
+    }
+    default:
+      return null;
+  }
+}
+
+/** Rewrite JSX into plain mdast before it reaches remark-rehype, which drops it. */
+function remarkFlattenMdx() {
+  return (tree) => {
+    // Bottom-up so replacing a parent cannot strand already-visited children.
+    const jsxNodes = [];
+    visit(tree, (node, index, parent) => {
+      if (
+        parent &&
+        (node.type === 'mdxJsxFlowElement' ||
+          node.type === 'mdxJsxTextElement' ||
+          node.type === 'mdxjsEsm' ||
+          node.type === 'mdxFlowExpression' ||
+          node.type === 'mdxTextExpression')
+      ) {
+        jsxNodes.push([node, index, parent]);
+      }
+    });
+
+    for (const [node, , parent] of jsxNodes.reverse()) {
+      const index = parent.children.indexOf(node);
+      if (index === -1) continue;
+
+      // Imports/exports and `{expressions}` have no feed-readable content.
+      if (
+        node.type !== 'mdxJsxFlowElement' &&
+        node.type !== 'mdxJsxTextElement'
+      ) {
+        parent.children.splice(index, 1);
+        continue;
+      }
+
+      const salvaged = fromProps(node);
+      if (salvaged) {
+        parent.children.splice(index, 1, ...salvaged);
+        continue;
+      }
+
+      const name = node.name;
+
+      if (name && VOID_AS.has(name)) {
+        parent.children.splice(index, 1, { ...VOID_AS.get(name) });
+        continue;
+      }
+
+      if (name && HEADING_AS.has(name)) {
+        parent.children.splice(index, 1, {
+          type: 'heading',
+          depth: HEADING_AS.get(name),
+          children: toPhrasing(node.children),
+        });
+        continue;
+      }
+
+      if (name && INLINE_AS.has(name)) {
+        parent.children.splice(index, 1, {
+          // `emphasis` is a phrasing node the tree already knows how to walk;
+          // `hName` swaps in the tag we actually want.
+          type: 'emphasis',
+          data: { hName: INLINE_AS.get(name) },
+          children: toPhrasing(node.children),
+        });
+        continue;
+      }
+
+      if (name && BLOCK_AS.has(name)) {
+        parent.children.splice(index, 1, {
+          type: 'blockquote',
+          data: { hName: BLOCK_AS.get(name) },
+          children: node.children || [],
+        });
+        continue;
+      }
+
+      if (node.name === 'a' || node.name === 'img') {
+        const props = literalAttrs(node);
+        parent.children.splice(
+          index,
+          1,
+          node.name === 'a'
+            ? { type: 'link', url: props.href || '#', children: node.children }
+            : { type: 'image', url: props.src || '', alt: props.alt || '' },
+        );
+        continue;
+      }
+
+      // Everything else — layout divs, spans, decorative components — is
+      // replaced by its own children.
+      parent.children.splice(index, 1, ...(node.children || []));
+    }
+  };
+}
+
+const BLOCK_TAGS = new Set([
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'p',
+  'div',
+  'ul',
+  'ol',
+  'li',
+  'blockquote',
+  'pre',
+  'table',
+  'hr',
+]);
+
+/**
+ * A heading written inline in the source (`<div><h1 …>` with no blank line)
+ * parses as phrasing content, which would leave a block element inside a `<p>`.
+ * Splice those paragraphs open so the output stays valid HTML.
+ */
+function rehypeUnwrapBlocksInParagraphs() {
+  const walk = (node) => {
+    if (!node.children) return;
+    node.children.forEach(walk);
+    const next = [];
+    let changed = false;
+    for (const child of node.children) {
+      const hasBlock =
+        child.type === 'element' &&
+        child.tagName === 'p' &&
+        child.children.some(
+          (g) => g.type === 'element' && BLOCK_TAGS.has(g.tagName),
+        );
+      if (hasBlock) {
+        next.push(...child.children);
+        changed = true;
+      } else {
+        next.push(child);
+      }
+    }
+    if (changed) node.children = next;
+  };
+  return (tree) => walk(tree);
+}
+
+/** Feed readers resolve relative URLs unpredictably, so make them absolute. */
+function rehypeAbsoluteUrls(siteUrl, locale) {
+  return (tree) => {
+    visit(tree, 'element', (node) => {
+      for (const [tag, prop] of [
+        ['a', 'href'],
+        ['img', 'src'],
+      ]) {
+        if (node.tagName !== tag) continue;
+        const value = node.properties?.[prop];
+        if (typeof value !== 'string' || !value.startsWith('/')) continue;
+        node.properties[prop] = value.startsWith('/blog/')
+          ? `${siteUrl}/${locale}${value}`
+          : `${siteUrl}${value}`;
+      }
+    });
+  };
+}
+
+const processor = (siteUrl, locale) =>
+  unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkMdx)
+    .use(remarkFlattenMdx)
+    .use(remarkRehype)
+    .use(rehypeUnwrapBlocksInParagraphs)
+    .use(() => rehypeAbsoluteUrls(siteUrl, locale))
+    .use(rehypeStringify);
+
+/**
+ * Returns HTML, or an empty string if the body cannot be parsed — a feed item
+ * that falls back to its summary beats failing the whole build.
+ */
+export function mdxToHtml(raw, { siteUrl, locale }) {
+  try {
+    return String(processor(siteUrl, locale).processSync(raw));
+  } catch (error) {
+    console.warn(`  ⚠  RSS 全文渲染失败，回退到摘要：${error.message}`);
+    return '';
+  }
+}

--- a/scripts/rss.mjs
+++ b/scripts/rss.mjs
@@ -7,28 +7,82 @@ import tagData from '../app/tag-data.json' with { type: 'json' };
 import { allBlogs } from '../.contentlayer/generated/index.mjs';
 import { sortPosts } from 'pliny/utils/contentlayer.js';
 import { defaultLocale } from '../lib/locales.mjs';
+import { mdxToHtml } from './mdxToHtml.mjs';
 
 const outputFolder = process.env.EXPORT ? 'out' : 'public';
+
+/**
+ * Full post bodies go in `content:encoded`, so a reader can show the whole
+ * article without a round trip. `description` stays the summary — that split is
+ * what the two elements are for.
+ *
+ * Only the main feed carries full text: the 51 tag feeds are subsets of the
+ * same posts, and duplicating every body across them multiplies the output for
+ * no benefit.
+ */
+const contentCache = new Map();
+
+function fullContent(config, post) {
+  if (!contentCache.has(post.slug)) {
+    contentCache.set(
+      post.slug,
+      mdxToHtml(post.body?.raw ?? '', {
+        siteUrl: config.siteUrl,
+        locale: defaultLocale,
+      }),
+    );
+  }
+  return contentCache.get(post.slug);
+}
+
+/**
+ * Characters XML 1.0 forbids outright — C0 controls, the U+FFFE/U+FFFF
+ * non-characters, and lone surrogates. CDATA does not exempt them and neither
+ * do numeric references, so they have to go.
+ *
+ * They show up here because posts quote source code: the SEO post includes the
+ * CJK-width regex `/[⺀-￿]/`, whose upper bound is U+FFFF. Rewriting such a
+ * character as its `\uXXXX` escape keeps the code sample both valid XML and
+ * valid JavaScript, which plain deletion would not.
+ */
+const XML_ILLEGAL =
+  // eslint-disable-next-line no-control-regex -- matching them is the point
+  /[\u0000-\u0008\u000B\u000C\u000E-\u001F\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/g;
+
+const sanitizeXml = (html) =>
+  html.replace(
+    XML_ILLEGAL,
+    (ch) =>
+      `\\u${ch.codePointAt(0).toString(16).toUpperCase().padStart(4, '0')}`,
+  );
+
+/** A literal `]]>` would terminate the CDATA section early. */
+const cdata = (html) =>
+  `<![CDATA[${sanitizeXml(html).replace(/]]>/g, ']]]]><![CDATA[>')}]]>`;
 
 // Routes are locale-prefixed; unprefixed URLs only redirect, so feed links and
 // GUIDs point straight at the canonical locale.
 const postUrl = (config, post) =>
   `${config.siteUrl}/${defaultLocale}/blog/${post.slug}`;
 
-const generateRssItem = (config, post) => `
+const generateRssItem = (config, post, { withContent }) => {
+  const content = withContent ? fullContent(config, post) : '';
+  return `
   <item>
     <guid>${postUrl(config, post)}</guid>
     <title>${escape(post.title)}</title>
     <link>${postUrl(config, post)}</link>
     ${post.summary && `<description>${escape(post.summary)}</description>`}
+    ${content && `<content:encoded>${cdata(content)}</content:encoded>`}
     <pubDate>${new Date(post.date).toUTCString()}</pubDate>
     <author>${config.email} (${config.author})</author>
     ${post.tags && post.tags.map((t) => `<category>${t}</category>`).join('')}
   </item>
 `;
+};
 
 const generateRss = (config, posts, page = 'feed.xml') => `
-  <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/">
     <channel>
       <title>${escape(config.title)}</title>
       <link>${config.siteUrl}/${defaultLocale}/blog</link>
@@ -42,7 +96,7 @@ const generateRss = (config, posts, page = 'feed.xml') => `
         <feedId>158720387189413888</feedId>
         <userId>71735074870774784</userId>
       </follow_challenge>
-      ${posts.map((post) => generateRssItem(config, post)).join('')}
+      ${posts.map((post) => generateRssItem(config, post, { withContent: page === 'feed.xml' })).join('')}
     </channel>
   </rss>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12602,7 +12602,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rehype-stringify@npm:^10.0.0":
+"rehype-stringify@npm:^10.0.0, rehype-stringify@npm:^10.0.1":
   version: 10.0.1
   resolution: "rehype-stringify@npm:10.0.1"
   dependencies:
@@ -12684,6 +12684,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-mdx@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "remark-mdx@npm:3.1.1"
+  dependencies:
+    mdast-util-mdx: ^3.0.0
+    micromark-extension-mdxjs: ^3.0.0
+  checksum: 9e6406ba83e545b5232ce98de71c29ad5746c2d920eed070a2c58687412453875bad52dfdfaf21bee6de59d3a45fa84cf785b3111c5eb4822f29b67cf1dfec96
+  languageName: node
+  linkType: hard
+
 "remark-parse@npm:^11.0.0":
   version: 11.0.0
   resolution: "remark-parse@npm:11.0.0"
@@ -12706,6 +12716,19 @@ __metadata:
     unified: ^11.0.0
     vfile: ^6.0.0
   checksum: e199dff098ae6a560e13dd1778dec9c61440f979cc931c4ca4dcde0d58e51c0723243a901c1842379b189083cf4d74f224f57833738095ffa9535179d7cf3f01
+  languageName: node
+  linkType: hard
+
+"remark-rehype@npm:^11.1.1":
+  version: 11.1.2
+  resolution: "remark-rehype@npm:11.1.2"
+  dependencies:
+    "@types/hast": ^3.0.0
+    "@types/mdast": ^4.0.0
+    mdast-util-to-hast: ^13.0.0
+    unified: ^11.0.0
+    vfile: ^6.0.0
+  checksum: 6eab55cb3464ec01d8e002cc9fe02ae57f48162899693fd53b5ba553ac8699dae7b55fce9df7131a5981313b19b495d6fbfa98a9d6bd243e7485591364d9b5b3
   languageName: node
   linkType: hard
 
@@ -13779,12 +13802,17 @@ __metadata:
     rehype-preset-minify: 7.0.0
     rehype-prism-plus: ^2.0.0
     rehype-slug: ^6.0.0
+    rehype-stringify: ^10.0.1
     remark: ^15.0.0
     remark-gfm: ^4.0.0
     remark-github-blockquote-alert: ^1.2.1
     remark-math: ^6.0.0
+    remark-mdx: ^3.1.0
+    remark-parse: ^11.0.0
+    remark-rehype: ^11.1.1
     tailwindcss: ^4.0.5
     typescript: ^5.1.3
+    unified: ^11.0.5
     unist-util-visit: ^5.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
`feed.xml` 此前只有 `description`（摘要），订阅者必须点回站点才能读正文。这是 GEO 评估里剩下的最后一项。

## 做法

全文放进 `content:encoded`，`description` 保留摘要——这正是这两个元素各自的用途。

难点在于正文是 MDX：18 篇里有 470 处 `<div className>`、22 个 `<Callout>`，还有 `ErrorDisplay`、`StepProgress`、`CopyableCodeBlock` 等自定义组件。contentlayer 只暴露 `body.raw`（MDX 源码）和 `body.code`（编译后的 bundle），没有现成 HTML。

新增 `scripts/mdxToHtml.mjs`，用 remark/rehype 管线处理：

- **剥离展示性 JSX** —— 阅读器没有样式表也没有 React，Tailwind 包装层没有意义，直接换成其内容
- **保留语义** —— `Callout` → `blockquote`，标题/列表/表格/行内标记按内容模型分别重建
- **抢救藏在 props 里的内容** —— `CopyableCodeBlock` 的 `code`、`ErrorDisplay` 的 `title`/`error` 都在属性里，单纯剥离会静默丢失
- **链接绝对化** —— 阅读器解析相对 URL 的行为不一致

标题和行内元素不能容纳块级 `<p>`，所以按内容模型分组重建，另加一个 rehype 收尾把含块级子元素的 `<p>` 拆开。18 篇输出均无非法嵌套、无 JSX 残留。

## 一个意外

`ElementTree` 解析失败，排查下来是文章引用的代码里含 **U+FFFF**——SEO 那篇引了 `check-seo` 的中文宽度正则 `/[⺀-￿]/`，上界正好是 U+FFFF。这个字符在 XML 1.0 里非法，**CDATA 和数字引用都救不了**。

处理成 `\uXXXX` 转义形式：既是合法 XML，在代码块语境里也仍是等价且可读的 JavaScript，比直接删掉好。顺带覆盖了 C0 控制字符和落单代理项。

## 取舍

`tag feeds` 保持摘要版。51 个标签 feed 都是同一批文章的子集，正文在里面重复没有收益，只会让输出膨胀数倍。

## 依赖

`remark-mdx`、`remark-rehype`、`rehype-stringify`、`remark-parse`、`unified` 从 contentlayer 的传递依赖提升为显式 devDependency——之前能 import 到纯属侥幸，contentlayer 一改就断。

## 验证

- `yarn build` 通过，`check-seo` 0 错误 0 警告
- `feed.xml` XML 解析通过：18 条 item，全部同时带 `content:encoded` 与 `description`
- 正文长度 416 / 6226 / 27635 字节（最小/中位/最大），feed 从 16 KB 增至 208 KB
- 相对链接残留 0；tag feed 确认仍无 `content:encoded`
- `public/feed.xml` 本就在 `.gitignore` 里，不会产生 diff 噪音

🤖 Generated with [Claude Code](https://claude.com/claude-code)